### PR TITLE
Document applock settings

### DIFF
--- a/docs/general-reference/devices.md
+++ b/docs/general-reference/devices.md
@@ -31,7 +31,7 @@ Currently, TestObject hosts <strong>more than 200 different models of real Andro
 
 <h3 id="free_pre">Free vs. Premium Devices</h3>
 
-While on a free (i.e. not premium) plan, you will be restricted to running your tests on free devices only. Free devices, just like premium ones, are real devices. The only difference is that they can be accessed from free users.
+While on a free (i.e. not premium) plan, you will be restricted to running your tests on free devices only. Free devices, just like premium ones, are real devices. On all free Android devices, access to Settings and Google Play Store is blocked. To access Settings and Google Play Store, it is necessary to upgrade to a premium plan.
 
 If you upgraded to a premium plan, you will be able to access and run your tests on a much wider array of devices. Due to our *Fair Use* policy, which is in place to ensure that no single user is blocking devices permanently, we reserve the right to limit the daily usage time, depending on the purchased plan. You can get more testing time by [upgrading your plan](/docs/general-reference/managing-your-account/#plans).
 


### PR DESCRIPTION
Users frequently ask why they can't access Settings and Play Store on
free devices. We should make this policy explicit on our help page.