### PR TITLE
MRDC-332: Update setups testobject-appium-java-api:0.0.26

### DIFF
--- a/docs/tools/appium/setups/suite-setup/setup-java-junit-suites.md
+++ b/docs/tools/appium/setups/suite-setup/setup-java-junit-suites.md
@@ -19,7 +19,7 @@ public class CompleteTestSetup {
     public TestName testName = new TestName();
 
     @Rule
-    public TestObjectTestResultWatcher resultWatcher = new TestObjectTestResultWatcher();
+    public TestObjectAppiumSuiteWatcher resultWatcher = new TestObjectAppiumSuiteWatcher();
 
     @Before
     public void setUp() throws Exception {
@@ -31,7 +31,7 @@ public class CompleteTestSetup {
 
         driver = new AndroidDriver(new URL("http://appium.testobject.com/wd/hub"), capabilities);
 
-        resultWatcher.setAppiumDriver(driver);
+        resultWatcher.setRemoteWebDriver(driver);
 
     }
 

--- a/docs/tools/appium/setups/watcher-setup/setup-java-junit-watcher.md
+++ b/docs/tools/appium/setups/watcher-setup/setup-java-junit-watcher.md
@@ -34,7 +34,7 @@ public class WatcherTestSetup {
         driver = new AndroidDriver(new URL("http://appium.testobject.com/wd/hub"), capabilities);
 
         /* IMPORTANT! We need to provide the Watcher with our initialized AppiumDriver */
-        resultWatcher.setAppiumDriver(driver);
+        resultWatcher.setRemoteWebDriver(driver);
 
     }
 


### PR DESCRIPTION
Most changes in the documentation for testobject-appium-java-api:0.0.26 were already handled in [this commit](https://github.com/testobject/help/commit/3cb1f64ee0d0ab2cb8acb19d1b526161f0c91896). All that is left is to update some method / class names.